### PR TITLE
fix: copy over hooks from base schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@
 const mongoose = require('mongoose');
 
 function extendSchema (Schema, definition, options) {
-  return new mongoose.Schema(
+  var toReturn = new mongoose.Schema(
     Object.assign({}, Schema.obj, definition),
     options
   );
+  toReturn.callQueue = [].concat(Schema.callQueue); // copy hooks
+  return toReturn;
 }
 
 module.exports = extendSchema;


### PR DESCRIPTION
Hi,

Thanks for the elegant lib! You're missing support for a couple things though, like copying hooks from the base schema (Automattic/mongoose#5897) .

An alternative implementation would be to do:

```javascript
function extendSchema(schema, definition) {
  var clone = schema.clone();
  schema.add(definition);
  return schema;
}
```

This will copy over hooks and everything else, like plugins, query methods, statics, etc. Any thoughts on that?